### PR TITLE
优化stop功能的边缘case

### DIFF
--- a/src/reactivity/tests/effect.spec.ts
+++ b/src/reactivity/tests/effect.spec.ts
@@ -71,8 +71,13 @@ describe('effect', () => {
         obj.prop = 2
         expect(dummy).toBe(2)
         stop(runner)
-        obj.prop = 3
-        expect(dummy).toBe(2)
+        // obj.prop = 3
+        // expect(dummy).toBe(2)
+
+
+        obj.prop++;
+        // get + set
+        expect(dummy).toBe(2);
 
         // stopped effect should still be manually callable
         runner()


### PR DESCRIPTION
 1.为防止cleanupEffects后再次收集依赖，需要增加全局参数判断是否需要收集
 2.在不是stop的情况下，将该参数置为true，可以正常收集，stop情况下，该参数默认是false