### PR TITLE
update

### DIFF
--- a/src/reactivity/baseHandler.ts
+++ b/src/reactivity/baseHandler.ts
@@ -1,12 +1,13 @@
 import { trigger, track } from './effect'
 import { reactiveFlags, readonly, reactive } from './reactive';
-import { isObject } from './shared/index';
+import { isObject, extend } from './shared/index';
 
 const get = createGetter();
 const set = createSetter();
 const readonlyGet = createGetter(true);
+const shallowReadonlyGet = createGetter(true, true);
 
-function createGetter(isReadonly = false) {
+function createGetter(isReadonly = false, shallow = false) {
     return (target, key) => {
         const res = Reflect.get(target, key);
 
@@ -14,6 +15,10 @@ function createGetter(isReadonly = false) {
             return !isReadonly;
         } else if (key === reactiveFlags.IS_READONLY) {
             return isReadonly;
+        }
+
+        if (shallow) {
+            return res;
         }
 
         if (isObject(res)) {
@@ -49,3 +54,7 @@ export const readonlyHandlers = {
         return true;
     }
 }
+
+export const shallowReadonlyHandlers = extend({}, readonlyHandlers, {
+    get: shallowReadonlyGet
+});

--- a/src/reactivity/effect.ts
+++ b/src/reactivity/effect.ts
@@ -61,7 +61,10 @@ export function track(target, key) {
         dep = new Set();
         depsMap.set(key, dep);
     }
-    // {foo:1,sys:2}
+    trackEffects(dep)
+}
+
+export function trackEffects(dep) {
     if (!activeEffect) return;
     if (!shouldTrack) return;
     dep.add(activeEffect);// 当前的effect
@@ -71,6 +74,10 @@ export function track(target, key) {
 export function trigger(target, key) {
     let depsMap = targetMap.get(target);
     let dep = depsMap.get(key);
+    triggerEffects(dep);
+}
+
+export function triggerEffects(dep) {
     for (const effect of dep) {
         if (effect.scheduler) {
             effect.scheduler();

--- a/src/reactivity/reactive.ts
+++ b/src/reactivity/reactive.ts
@@ -1,4 +1,4 @@
-import { mutatableHandlers, readonlyHandlers } from './baseHandler';
+import { mutatableHandlers, readonlyHandlers, shallowReadonlyHandlers } from './baseHandler';
 export const enum reactiveFlags {
     IS_REACTIVE = '__v_isReactive',
     IS_READONLY = '__v_isReadonly',
@@ -6,11 +6,11 @@ export const enum reactiveFlags {
 
 
 export function reactive(raw) {
-    return new Proxy(raw, mutatableHandlers)
+    return createReactiveObject(raw, mutatableHandlers);
 }
 
 export function readonly(raw) {
-    return new Proxy(raw, readonlyHandlers)
+    return createReactiveObject(raw, readonlyHandlers);
 }
 
 export function isReactive(raw) {
@@ -19,4 +19,16 @@ export function isReactive(raw) {
 
 export function isReadonly(raw) {
     return !!raw[reactiveFlags.IS_READONLY];
+}
+
+export function shallowReadonly(raw) {
+    return createReactiveObject(raw, shallowReadonlyHandlers);
+}
+
+export function isProxy(raw) {
+    return isReadonly(raw) || isReactive(raw);
+}
+
+function createReactiveObject(target, baseHandlers) {
+    return new Proxy(target, baseHandlers);
 }

--- a/src/reactivity/ref.ts
+++ b/src/reactivity/ref.ts
@@ -1,0 +1,35 @@
+import { track, trackEffects, triggerEffects } from './effect'
+import { reactive } from './reactive';
+import { isObject } from './shared';
+class RefImpl {
+    private _value: any;
+    private _raw: any;
+    public dep: any;
+    constructor(value) {
+        this._raw = value;
+        this._value = this.convert(value);
+        this.dep = new Set();
+    }
+
+    get value() {
+        trackEffects(this.dep);
+        return this._value
+    }
+
+    set value(newValue) {
+        if (Object.is(newValue, this._raw)) return;
+        this._raw = newValue;
+        this._value = this.convert(newValue);
+        triggerEffects(this.dep);
+    }
+
+    convert(value) {
+        return isObject(value) ? reactive(value) : value;
+    }
+}
+
+
+
+export function ref(value) {
+    return new RefImpl(value);
+}

--- a/src/reactivity/tests/reactive.spec.ts
+++ b/src/reactivity/tests/reactive.spec.ts
@@ -1,4 +1,4 @@
-import { reactive, isReactive, isReadonly, readonly } from '../reactive';
+import { reactive, isReactive, isReadonly, readonly, isProxy } from '../reactive';
 
 describe('reactive', () => {
 
@@ -14,6 +14,9 @@ describe('reactive', () => {
         const read = readonly(original);
         expect(isReadonly(read)).toBe(true);
         expect(isReadonly(observed)).toBe(false);
+
+
+        expect(isProxy(observed)).toBe(true);
     })
 
     it('nested reactives', () => {

--- a/src/reactivity/tests/readonly.spec.ts
+++ b/src/reactivity/tests/readonly.spec.ts
@@ -1,4 +1,4 @@
-import {readonly} from '../reactive';
+import { isReadonly, readonly, shallowReadonly } from '../reactive';
 
 describe('readonly', () => {
     it('happy path', () => {
@@ -8,4 +8,13 @@ describe('readonly', () => {
         expect(wrapped).not.toBe(original);
         expect(wrapped.foo).toBe(1);
     });
+})
+
+
+describe('shadowReadonly', () => {
+    it('shallow', () => {
+        const props = shallowReadonly({ n: { foo: 1 } });
+        expect(isReadonly(props)).toBe(true);
+        expect(isReadonly(props.n)).toBe(false);
+    })
 })

--- a/src/reactivity/tests/ref.spec.ts
+++ b/src/reactivity/tests/ref.spec.ts
@@ -1,0 +1,42 @@
+import { ref } from "../ref";
+import { effect } from '../effect'
+
+describe('ref', () => {
+    it('happy path', () => {
+        const a = ref(1);
+        expect(a.value).toBe(1);
+    })
+
+    it('should be reactive', () => {
+        const a = ref(1)
+        let dummy
+        let calls = 0
+        effect(() => {
+            calls++
+            dummy = a.value
+        })
+        expect(calls).toBe(1)
+        expect(dummy).toBe(1)
+        a.value = 2
+        expect(calls).toBe(2)
+        expect(dummy).toBe(2)
+        // same value should not trigger
+        a.value = 2
+        expect(calls).toBe(2)
+        expect(dummy).toBe(2)
+    })
+
+    it('should make nested properties reactive', () => {
+        const a = ref({
+            count: 1
+        })
+        let dummy
+        effect(() => {
+            dummy = a.value.count
+        })
+        expect(dummy).toBe(1)
+        a.value.count = 2
+        expect(dummy).toBe(2)
+    })
+
+})


### PR DESCRIPTION
1. shallowReadonly 的实现：判断是shallow的话 getter的时候不会用reactive或者readonly包裹一下，直接返回原值
2. ref的实现：特殊的reactive，key为value。复用依赖触发收集的机制。